### PR TITLE
Corregir error crítico en gestión de libros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Hotfix: Fix Book Management Bug
+
+Esta rama corrige un error crítico en la funcionalidad de gestión de libros.
+
+## Descripción
+
+- Corrige un error que permitía la adición de libros duplicados.
+- Asegura que la funcionalidad de gestión de libros sea estable y libre de errores críticos.
+
+## Cómo Contribuir
+
+1. Realiza cambios para corregir errores críticos en esta rama.
+2. Crea un pull request a `main` después de verificar que el error está solucionado.
+3. Fusiona los cambios también en la rama `dev` si es necesario.

--- a/main
+++ b/main
@@ -1,1 +1,19 @@
 
+# book_management.py (corrección de error crítico)
+class Book:
+    def __init__(self, title, author):
+        self.title = title
+        self.author = author
+
+class BookManager:
+    def __init__(self):
+        self.books = []
+
+    def add_book(self, book):
+        if not any(b.title == book.title for b in self.books):
+            self.books.append(book)
+        else:
+            raise ValueError("El libro ya existe.")
+
+    def list_books(self):
+        return [f"{book.title} by {book.author}" for book in self.books]


### PR DESCRIPTION
Este PR corrige un error crítico en la funcionalidad de gestión de libros. El error permitía la adición de libros duplicados. La solución ha sido implementada y está lista para ser fusionada con la rama principal.

#4 